### PR TITLE
support multiple target in one repository

### DIFF
--- a/get_latest_ssl_tools.sh
+++ b/get_latest_ssl_tools.sh
@@ -35,6 +35,8 @@ USAGE
 }
 
 TARGET_TOOL_NAME=""
+TARGET_TOOL_REPOSITORY=""
+TARGET_TOOL_REPOSITORY_API_ROOT=""
 
 # support multiple target in argments : split argment and run script itself for each
 if [ "$#" -ge 2 ]; then
@@ -55,14 +57,19 @@ case "$1" in
     | "ssl-game-controller" \
     | "game-controller" \
     | "gc")
-        TARGET_TOOL_NAME="robocup-ssl/ssl-game-controller"
+        TARGET_TOOL_REPOSITORY_API_ROOT="https://api.github.com/repos/"
+        TARGET_TOOL_REPOSITORY="robocup-ssl/ssl-game-controller"
+        TARGET_TOOL_NAME="ssl-game-controller"
         ;;
     "robocup-ssl/ssl-vision-client" \
     | "ssl-vision-client" \
     | "vision-client" \
     | "vc" \
     )
-        TARGET_TOOL_NAME="robocup-ssl/ssl-vision-client"
+        TARGET_TOOL_REPOSITORY_API_ROOT="https://api.github.com/repos/"
+        TARGET_TOOL_REPOSITORY="robocup-ssl/ssl-vision-client"
+        TARGET_TOOL_NAME="ssl-vision-client"
+        ;;
         ;;
     "--all" \
     | "-a" )
@@ -107,7 +114,10 @@ case "$(uname -s)" in
 esac
 
 # set up target and its URL, then display it
-TARGET_FILE_URL="$(curl -Ss https://api.github.com/repos/${TARGET_TOOL_NAME}/releases | jq -r --arg TARGET_PLATFORM "${TARGET_PLATFORM}" '.[0].assets[] | select(.name | test($TARGET_PLATFORM)) | .browser_download_url')"
+TARGET_FILE_URL="$(curl -Ss "${TARGET_TOOL_REPOSITORY_API_ROOT}${TARGET_TOOL_REPOSITORY}/releases" \
+    | jq -r --arg TARGET_PLATFORM "${TARGET_PLATFORM}" --arg TARGET_TOOL_NAME "${TARGET_TOOL_NAME}_" \
+        '.[0].assets[] | select(.name | test($TARGET_TOOL_NAME)) | select(.name | test($TARGET_PLATFORM)) | .browser_download_url')"
+
 TARGET_TOOL_VERSION="$(basename ${TARGET_FILE_URL} | cut -d '_' -f 2)"
 cat << TARGET_INFO
 Download latest release of ${TARGET_TOOL_NAME}
@@ -126,7 +136,7 @@ fi
 
 # find older version and ask to delete before downloading latest one
 EXEC_NAME_SIMPLIFIED="$(echo "${TARGET_FILE_NAME}" | cut -d "_" -f 1)"
-OLDER_LIST="$(find ~/ -executable -type f -name "${EXEC_NAME_SIMPLIFIED}*")"
+OLDER_LIST="$(find ~/ -executable -type f -name "${EXEC_NAME_SIMPLIFIED}_*")"
 for older_file in ${OLDER_LIST}; do
     printf "Older version of target found:\n"
     du -h "${older_file}"


### PR DESCRIPTION
Partially solves #2

for ssl-visioni-client and ssl-vision-cli
It shares same repo https://github.com/robocup-ssl/ssl-vision-client
so jq result contains multiple value that cannot download at once

This commit introduces concepts:
- TARGET_TOOL_REPOSITORY
  is e.g. robocup-ssl/ssl-vision-client
- TARGET_TOOL_REPOSITORY_API_ROOT
  is e.g. https://api.github.com/repo/
then TARGET_TOOL_NAME is used in jq query

Note:
This commit expect that target binary file is
like

  TOOL-NAME_vVERSION_ARCHTECTURE

I mean "_" is exist between tool name and version to support ssl-vision-client and ssl-vision-cli,  
that have mostly same name.  

To identify them, This tool will query with "TOOOL-NAME_"