### PR TITLE
support `ssl-remote-control`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ available tools are:
     aliases : ssl-vision-client, vision-client, vc
 - [robocup-ssl/ssl-vision-client::vision-cli](https://github.com/robocup-ssl/ssl-vision-client)  
     aliases : ssl-vision-cli, vision-client, vcli
+- [robocup-ssl/ssl-remote-control](https://github.com/robocup-ssl/ssl-remote-control)  
+    aliases : ssl-remote-control, remote-control, rc
 
 ## example usage
 

--- a/get_latest_ssl_tools.sh
+++ b/get_latest_ssl_tools.sh
@@ -27,6 +27,8 @@ print_usage() {
       aliases : ssl-vision-client, vision-client, vc
     - robocup-ssl/ssl-vision-client::ssl-vision-cli
       aliases : ssl-vision-cli, vision-cli, vcli
+    - robocup-ssl/ssl-remote-control
+      aliases : ssl-remote-control, remote-control, rc
     example
     $ $(basename $0) robocup-ssl/ssl-vision-client
     $ $(basename $0) gc
@@ -85,12 +87,21 @@ case "$1" in
         TARGET_TOOL_REPOSITORY="robocup-ssl/ssl-vision-client"
         TARGET_TOOL_NAME="ssl-vision-cli"
         ;;
+    "robocup-ssl/ssl-remote-control" \
+    | "ssl-remote-control" \
+    | "remote-control" \
+    | "rc" \
+    )
+        TARGET_TOOL_REPOSITORY_API_ROOT="https://api.github.com/repos/"
+        TARGET_TOOL_REPOSITORY="robocup-ssl/ssl-remote-control"
+        TARGET_TOOL_NAME="ssl-remote-control"
+        ;;
     "--all" \
     | "-a" \
     | "all" \
     )
         printf "Downlaod all supported tools\n\n"
-        env sh "$0" gc vc vcli
+        env sh "$0" gc vc vcli rc
         exit 0
         ;;
     *)


### PR DESCRIPTION
close #6 

https://github.com/robocup-ssl/ssl-remote-control

> SSL Remote Control that allows the robot handler (human) to interact with the ssl-game-controller 

aliases : `ssl-remote-control`, `remote-control`, `rc` 